### PR TITLE
Remove an extra socket shutdown, cleanup an API name, validate API pointer

### DIFF
--- a/mbed-net-sockets/TCPStream.h
+++ b/mbed-net-sockets/TCPStream.h
@@ -51,7 +51,7 @@ public:
 	 * This handler only needs to be configured once onConnect has been called
 	 * @param[in] h the handler to call when a connection is disconnected
 	 */
-	void onDisconnect(const handler_t h) { _onDisconnect = h; }
+	void setOnDisconnect(const handler_t h) { _onDisconnect = h; }
 
 protected:
 	/**

--- a/source/Socket.cpp
+++ b/source/Socket.cpp
@@ -34,8 +34,10 @@ Socket::Socket(const socket_stack_t stack) :
 }
 Socket::~Socket()
 {
-    socket_error_t err = _socket.api->destroy(&_socket);
-    error_check(err);
+    if(_socket.api != NULL && _socket.api->destroy != NULL) {
+        socket_error_t err = _socket.api->destroy(&_socket);
+        error_check(err);
+    }
 }
 
 socket_error_t Socket::open(const socket_address_family_t af, const socket_proto_family_t pf)

--- a/source/TCPAsynch.cpp
+++ b/source/TCPAsynch.cpp
@@ -46,7 +46,6 @@ socket_error_t TCPAsynch::open(const socket_address_family_t af)
 
 TCPAsynch::~TCPAsynch()
 {
-	_socket.api->destroy(&_socket);
 	_TCPSockets--;
 	if (!_TCPSockets) {
 		_ticker.detach();


### PR DESCRIPTION
Correct a number of errors surrounding session termination, raised by OOB testing
- Check API pointers before using them in destructor
- Check socket_destroy is not necessary in TCPAsynch, since it is handled in Socket
- onDisconnect is inconsistent with other API naming, so renamed to setOnDisconnect
