### PR TITLE
Let resolve to work before connect/bind.

### DIFF
--- a/source/Socket.cpp
+++ b/source/Socket.cpp
@@ -24,7 +24,7 @@ Socket::Socket(const socket_stack_t stack) :
     _irq(this), _event(NULL)
 {
     _irq.callback(&Socket::_nvEventHandler);
-    _socket.handler = NULL;
+    _socket.handler = (socket_api_handler_t)_irq.entry();
     _socket.impl = NULL;
     _socket.stack = stack;
     _socket.api = socket_get_api(stack);


### PR DESCRIPTION
The handler was not originally set here because it is set in the socket create API.  Because socket create is deferred until open/bind--for late resolution of address family--the handler was not set until open/bind were executed.  This prevents DNS operations before open/bind which is counter-productive.

Set the handler in the constructor so that resolve works immediately after construction.
