### PR TITLE
Override a potentially problematic virtual open

### DIFF
--- a/mbed-net-sockets/v0/TCPAsynch.h
+++ b/mbed-net-sockets/v0/TCPAsynch.h
@@ -40,6 +40,8 @@ protected:
     // counter overflow if the counter is the same size as the pointer type and
     // sizeof(TCPAsynch) > 0
     static uintptr_t _TCPSockets;
+private:
+    socket_error_t open(const socket_address_family_t af, const socket_proto_family_t pf);
 };
 } // namespace v0
 } // namespace Sockets

--- a/mbed-net-sockets/v0/UDPSocket.h
+++ b/mbed-net-sockets/v0/UDPSocket.h
@@ -57,6 +57,9 @@ public:
      * @return SOCKET_ERROR_NONE on success, or an error code on failure
      */
     socket_error_t connect(const SocketAddr *address, const uint16_t port);
+private:
+    socket_error_t open(const socket_address_family_t af, const socket_proto_family_t pf);
+
 };
 } // namespace v0
 } // namespace Sockets

--- a/source/v0/TCPAsynch.cpp
+++ b/source/v0/TCPAsynch.cpp
@@ -42,6 +42,13 @@ socket_error_t TCPAsynch::open(const socket_address_family_t af)
     return err;
 }
 
+socket_error_t TCPAsynch::open(const socket_address_family_t af, const socket_proto_family_t pf)
+{
+    (void)af;
+    (void)pf;
+    return SOCKET_ERROR_UNIMPLEMENTED;
+}
+
 TCPAsynch::~TCPAsynch()
 {
     _TCPSockets--;

--- a/source/v0/UDPSocket.cpp
+++ b/source/v0/UDPSocket.cpp
@@ -34,3 +34,10 @@ socket_error_t UDPSocket::connect(const SocketAddr *address, const uint16_t port
     socket_error_t err = _socket.api->connect(&_socket, address->getAddr(), port);
     return err;
 }
+
+socket_error_t UDPSocket::open(const socket_address_family_t af, const socket_proto_family_t pf)
+{
+    (void)af;
+    (void)pf;
+    return SOCKET_ERROR_UNIMPLEMENTED;
+}


### PR DESCRIPTION
Overriding in the private context prevents the two-argument open from being called in a public context.

This should fix https://github.com/ARMmbed/sockets/issues/23

@mpg @bogdanm 
