### PR TITLE
Updating sockets to be compatible with mbed-drivers 0.8.x and minar 0…

### DIFF
--- a/mbed-net-sockets/v0/Socket.h
+++ b/mbed-net-sockets/v0/Socket.h
@@ -21,10 +21,12 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "mbed.h"
-#include "FunctionPointer.h"
+#include "mbed-util/FunctionPointer.h"
 #include "CThunk.h"
 #include "mbed-net-socket-abstract/socket_types.h"
 #include "SocketAddr.h"
+
+using namespace mbed::util;
 
 namespace mbed {
 namespace Sockets {

--- a/mbed-net-sockets/v0/TCPListener.h
+++ b/mbed-net-sockets/v0/TCPListener.h
@@ -19,9 +19,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed/FunctionPointer.h"
+#include "mbed-util/FunctionPointer.h"
 #include "TCPAsynch.h"
 #include "TCPStream.h"
+
+using namespace mbed::util;
 
 namespace mbed {
 namespace Sockets {

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "sockets",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "C++ Asynchronous Sockets Layer",
   "keywords": [
     "mbed",
@@ -15,9 +15,9 @@
     }
   ],
   "dependencies": {
-    "mbed-drivers": "~0.6.3",
+    "mbed-drivers": "~0.8.0",
     "sal": "~0.2.1",
-    "minar": "~0.6.3"
+    "minar": "~0.7.0"
   },
   "scripts": {
     "testReporter": [


### PR DESCRIPTION
@bremoran Please review the changes , this was required because mbed-drivers and minar modules were updated and FunctionPointer.h was moved from mbed-drivers module to mbed-util module so I had to make some modifications for sockets to compile.