### PR TITLE
Update sockets dependencies from mbed-drivers to core-util.

### DIFF
--- a/mbed-net-sockets/v0/Socket.h
+++ b/mbed-net-sockets/v0/Socket.h
@@ -21,7 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "mbed.h"
-#include "FunctionPointer.h"
+#include "mbed-util/FunctionPointer.h"
 #include "CThunk.h"
 #include "mbed-net-socket-abstract/socket_types.h"
 #include "SocketAddr.h"
@@ -37,10 +37,10 @@ namespace v0 {
  */
 class Socket {
 public:
-    typedef FunctionPointer3<void, Socket *, struct socket_addr, const char *> DNSHandler_t;
-    typedef FunctionPointer2<void, Socket *, socket_error_t> ErrorHandler_t;
-    typedef FunctionPointer1<void, Socket *> ReadableHandler_t;
-    typedef FunctionPointer2<void, Socket *, uint16_t> SentHandler_t;
+    typedef mbed::util::FunctionPointer3<void, Socket *, struct socket_addr, const char *> DNSHandler_t;
+    typedef mbed::util::FunctionPointer2<void, Socket *, socket_error_t> ErrorHandler_t;
+    typedef mbed::util::FunctionPointer1<void, Socket *> ReadableHandler_t;
+    typedef mbed::util::FunctionPointer2<void, Socket *, uint16_t> SentHandler_t;
 protected:
     /**
      * Socket constructor

--- a/mbed-net-sockets/v0/TCPAsynch.h
+++ b/mbed-net-sockets/v0/TCPAsynch.h
@@ -34,7 +34,7 @@ public:
     virtual socket_error_t open(const socket_address_family_t af);
 protected:
     static Ticker _ticker;
-    static FunctionPointer0<void> _tick_handler;
+    static mbed::util::FunctionPointer0<void> _tick_handler;
     // uintptr_t is used to guarantee that there will always be a large enough
     // counter to avoid overflows. Memory allocation will always fail before
     // counter overflow if the counter is the same size as the pointer type and

--- a/mbed-net-sockets/v0/TCPListener.h
+++ b/mbed-net-sockets/v0/TCPListener.h
@@ -19,7 +19,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed/FunctionPointer.h"
+#include "mbed-util/FunctionPointer.h"
 #include "TCPAsynch.h"
 #include "TCPStream.h"
 
@@ -32,7 +32,7 @@ namespace v0 {
  */
 class TCPListener: public TCPAsynch {
 public:
-    typedef FunctionPointer2<void, TCPListener *, void *> IncomingHandler_t;
+    typedef mbed::util::FunctionPointer2<void, TCPListener *, void *> IncomingHandler_t;
     /**
      *  The TCP Listener constructor.
      * @param[in] stack the network stack to use

--- a/mbed-net-sockets/v0/TCPStream.h
+++ b/mbed-net-sockets/v0/TCPStream.h
@@ -27,8 +27,8 @@ namespace v0 {
 
 class TCPStream: public TCPAsynch {
 public:
-    typedef FunctionPointer1<void, TCPStream *> ConnectHandler_t;
-    typedef FunctionPointer1<void, TCPStream *> DisconnectHandler_t;
+    typedef mbed::util::FunctionPointer1<void, TCPStream *> ConnectHandler_t;
+    typedef mbed::util::FunctionPointer1<void, TCPStream *> DisconnectHandler_t;
     /**
      * TCP socket constructor.
      * Does not allocate an underlying TCP Socket instance.

--- a/module.json
+++ b/module.json
@@ -15,9 +15,9 @@
     }
   ],
   "dependencies": {
-    "mbed-drivers": "~0.6.3",
     "sal": "~0.2.1",
-    "minar": "~0.6.3"
+    "core-util" : "~0.1.2",
+    "minar": "~0.7.0"
   },
   "scripts": {
     "testReporter": [

--- a/source/v0/TCPAsynch.cpp
+++ b/source/v0/TCPAsynch.cpp
@@ -23,7 +23,7 @@ using namespace mbed::Sockets::v0;
 
 uintptr_t TCPAsynch::_TCPSockets = 0;
 Ticker TCPAsynch::_ticker;
-FunctionPointer0<void> TCPAsynch::_tick_handler(NULL);
+mbed::util::FunctionPointer0<void> TCPAsynch::_tick_handler(NULL);
 
 TCPAsynch::TCPAsynch(const socket_stack_t stack) :
         Socket(stack)

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -21,6 +21,7 @@
 #include "mbed-net-lwip/lwipv4_init.h"
 #include "EthernetInterface.h"
 #include "minar/minar.h"
+#include "mbed-util/FunctionPointer.h"
 
 struct s_ip_address {
     int ip_1;
@@ -35,7 +36,7 @@ using namespace mbed::Sockets::v0;
 EthernetInterface eth;
 
 class TCPEchoClient;
-typedef FunctionPointer2<void, bool, TCPEchoClient*> fpterminate_t;
+typedef mbed::util::FunctionPointer2<void, bool, TCPEchoClient*> fpterminate_t;
 void terminate(bool status, TCPEchoClient* client);
 
 char out_buffer[] = "Hello World\n";
@@ -183,7 +184,7 @@ void app_start(int argc, char *argv[]) {
     client = new TCPEchoClient(SOCKET_STACK_LWIP_IPV4);
 
     {
-        FunctionPointer2<void, char *, uint16_t> fp(client, &TCPEchoClient::start_test);
+        mbed::util::FunctionPointer2<void, char *, uint16_t> fp(client, &TCPEchoClient::start_test);
         minar::Scheduler::postCallback(fp.bind(buffer, port));
     }
 }

--- a/test/echo-udp-client/main.cpp
+++ b/test/echo-udp-client/main.cpp
@@ -23,6 +23,7 @@
 #include "EthernetInterface.h"
 #include "mbed-net-lwip/lwipv4_init.h"
 #include "minar/minar.h"
+#include "mbed-util/FunctionPointer.h"
 
 #define CHECK(RC, STEP)       if (RC < 0) error(STEP": %d\r\n", RC)
 
@@ -51,7 +52,7 @@ char char_rand() {
 #endif
 
 class UDPEchoClient;
-typedef FunctionPointer2<void, bool, UDPEchoClient*> fpterminate_t;
+typedef mbed::util::FunctionPointer2<void, bool, UDPEchoClient*> fpterminate_t;
 void terminate(bool status, UDPEchoClient* client);
 
 char buffer[BUFFER_SIZE] = {0};
@@ -182,7 +183,7 @@ void app_start(int argc, char *argv[]) {
     sprintf(buffer, "%d.%d.%d.%d", ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4);
 
     {
-        FunctionPointer2<void, char *, uint16_t> fp(ec, &UDPEchoClient::start_test);
+        mbed::util::FunctionPointer2<void, char *, uint16_t> fp(ec, &UDPEchoClient::start_test);
         minar::Scheduler::postCallback(fp.bind(buffer, port));
     }
 }


### PR DESCRIPTION
Update sockets dependencies.  Only FunctionPointer was used from mbed-drivers, so remove the mbed-drivers dependency and update to core-util.

@yogpan01 