### PR TITLE
Use MINAR to invoke the periodic function

### DIFF
--- a/mbed-net-sockets/v0/Socket.h
+++ b/mbed-net-sockets/v0/Socket.h
@@ -21,7 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "mbed.h"
-#include "mbed-util/FunctionPointer.h"
+#include "core-util/FunctionPointer.h"
 #include "CThunk.h"
 #include "mbed-net-socket-abstract/socket_types.h"
 #include "SocketAddr.h"

--- a/mbed-net-sockets/v0/TCPAsynch.h
+++ b/mbed-net-sockets/v0/TCPAsynch.h
@@ -20,7 +20,7 @@
 #include "Socket.h"
 #include "mbed-net-socket-abstract/socket_api.h"
 
-#include "Ticker.h"
+#include "minar/minar.h"
 
 namespace mbed {
 namespace Sockets {
@@ -33,8 +33,7 @@ protected:
 public:
     virtual socket_error_t open(const socket_address_family_t af);
 protected:
-    static Ticker _ticker;
-    static mbed::util::FunctionPointer0<void> _tick_handler;
+    static minar::callback_handle_t _tick_handle;
     // uintptr_t is used to guarantee that there will always be a large enough
     // counter to avoid overflows. Memory allocation will always fail before
     // counter overflow if the counter is the same size as the pointer type and

--- a/mbed-net-sockets/v0/TCPListener.h
+++ b/mbed-net-sockets/v0/TCPListener.h
@@ -19,7 +19,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed-util/FunctionPointer.h"
+#include "core-util/FunctionPointer.h"
 #include "TCPAsynch.h"
 #include "TCPStream.h"
 

--- a/module.json
+++ b/module.json
@@ -15,9 +15,9 @@
     }
   ],
   "dependencies": {
-    "sal": "~0.2.1",
-    "core-util": "~0.1.2",
-    "minar": "~0.7.0"
+    "sal": "~0.2.3",
+    "core-util" : "~0.2.1",
+    "minar": "~0.8.1"
   },
   "scripts": {
     "testReporter": [

--- a/source/v0/TCPAsynch.cpp
+++ b/source/v0/TCPAsynch.cpp
@@ -53,5 +53,6 @@ TCPAsynch::~TCPAsynch()
     _TCPSockets--;
     if (!_TCPSockets) {
         minar::Scheduler::cancelCallback(_tick_handle);
+        _tick_handle = 0;
     }
 }

--- a/source/v0/TCPAsynch.cpp
+++ b/source/v0/TCPAsynch.cpp
@@ -15,24 +15,23 @@
  * limitations under the License.
  */
 
-#include "Ticker.h"
+#include "minar/minar.h"
 #include "mbed-net-sockets/v0/TCPAsynch.h"
 #include "mbed-net-socket-abstract/socket_api.h"
 
 using namespace mbed::Sockets::v0;
 
 uintptr_t TCPAsynch::_TCPSockets = 0;
-Ticker TCPAsynch::_ticker;
-mbed::util::FunctionPointer0<void> TCPAsynch::_tick_handler(NULL);
+minar::callback_handle_t TCPAsynch::_tick_handle(NULL);
 
 TCPAsynch::TCPAsynch(const socket_stack_t stack) :
         Socket(stack)
 {
     _socket.family = SOCKET_STREAM;
     if (_TCPSockets == 0) {
-        timestamp_t timeout = _socket.api->periodic_interval(&_socket) * 1000;
+        uint32_t timeout = _socket.api->periodic_interval(&_socket);
         void (*f)() = _socket.api->periodic_task(&_socket);
-        _ticker.attach_us(f, timeout);
+        _tick_handle = minar::Scheduler::postCallback(f).period(minar::milliseconds(timeout)).tolerance(timeout/2).getHandle();
     }
     _TCPSockets++;
 }
@@ -53,6 +52,6 @@ TCPAsynch::~TCPAsynch()
 {
     _TCPSockets--;
     if (!_TCPSockets) {
-        _ticker.detach();
+        minar::Scheduler::cancelCallback(_tick_handle);
     }
 }

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -21,7 +21,7 @@
 #include "mbed-net-lwip/lwipv4_init.h"
 #include "EthernetInterface.h"
 #include "minar/minar.h"
-#include "mbed-util/FunctionPointer.h"
+#include "core-util/FunctionPointer.h"
 
 struct s_ip_address {
     int ip_1;

--- a/test/echo-udp-client/main.cpp
+++ b/test/echo-udp-client/main.cpp
@@ -23,7 +23,7 @@
 #include "EthernetInterface.h"
 #include "mbed-net-lwip/lwipv4_init.h"
 #include "minar/minar.h"
-#include "mbed-util/FunctionPointer.h"
+#include "core-util/FunctionPointer.h"
 
 #define CHECK(RC, STEP)       if (RC < 0) error(STEP": %d\r\n", RC)
 


### PR DESCRIPTION
MINAR should be used to invoke the socket stack's periodic function.  This will allow MINAR to do aggregation with other API calls.