### PR TITLE
Fix include warnings from changes in other modules

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,9 +16,12 @@
     }
   ],
   "dependencies": {
-    "sal": "^1.0.0",
+    "sal": "^1.0.1",
     "core-util": "^1.0.0",
     "minar": "^1.0.0"
+  },
+  "testDependencies" : {
+    "mbed-drivers" : "~0.11.1"
   },
   "scripts": {
     "testReporter": [

--- a/sockets/v0/Socket.h
+++ b/sockets/v0/Socket.h
@@ -20,10 +20,10 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed.h"
+#include "mbed-drivers/mbed.h"
 #include "core-util/FunctionPointer.h"
-#include "CThunk.h"
-#include "mbed-net-socket-abstract/socket_types.h"
+#include "mbed-drivers/CThunk.h"
+#include "sal/socket_types.h"
 #include "SocketAddr.h"
 
 namespace mbed {

--- a/sockets/v0/SocketAddr.h
+++ b/sockets/v0/SocketAddr.h
@@ -17,7 +17,7 @@
 #ifndef __SOCKETS_V0_SOCKETADDR_H__
 #define __SOCKETS_V0_SOCKETADDR_H__
 
-#include "mbed-net-socket-abstract/socket_types.h"
+#include "sal/socket_types.h"
 
 namespace mbed {
 namespace Sockets {

--- a/sockets/v0/TCPAsynch.h
+++ b/sockets/v0/TCPAsynch.h
@@ -18,7 +18,7 @@
 #define __MBED_NET_SOCKETS_V0_TCP_ASYNCH__
 
 #include "Socket.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 
 #include "minar/minar.h"
 

--- a/sockets/v0/TCPStream.h
+++ b/sockets/v0/TCPStream.h
@@ -18,7 +18,6 @@
 #define __SOCKETS_V0_TCPSTREAM_H__
 #include <stddef.h>
 #include <stdint.h>
-#include "Ticker.h"
 #include "TCPAsynch.h"
 
 namespace mbed {

--- a/source/v0/Socket.cpp
+++ b/source/v0/Socket.cpp
@@ -16,7 +16,7 @@
  */
 #include "sockets/v0/Socket.h"
 #include "minar/minar.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 #include "cmsis.h"
 
 using namespace mbed::Sockets::v0;

--- a/source/v0/SocketAddr.cpp
+++ b/source/v0/SocketAddr.cpp
@@ -18,7 +18,7 @@
 #include <stdio.h>
 
 #include "sockets/v0/SocketAddr.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 
 using namespace mbed::Sockets::v0;
 

--- a/source/v0/TCPAsynch.cpp
+++ b/source/v0/TCPAsynch.cpp
@@ -17,7 +17,7 @@
 
 #include "minar/minar.h"
 #include "sockets/v0/TCPAsynch.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 
 using namespace mbed::Sockets::v0;
 

--- a/source/v0/TCPListener.cpp
+++ b/source/v0/TCPListener.cpp
@@ -17,7 +17,7 @@
 
 #include "sockets/v0/TCPListener.h"
 #include "sockets/v0/TCPStream.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 #include "minar/minar.h"
 
 using namespace mbed::Sockets::v0;

--- a/source/v0/TCPStream.cpp
+++ b/source/v0/TCPStream.cpp
@@ -16,7 +16,7 @@
  */
 #include "sockets/v0/TCPStream.h"
 #include "sockets/v0/SocketAddr.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 #include "minar/minar.h"
 
 using namespace mbed::Sockets::v0;

--- a/source/v0/UDPSocket.cpp
+++ b/source/v0/UDPSocket.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 #include "sockets/v0/UDPSocket.h"
-#include "mbed-net-socket-abstract/socket_api.h"
+#include "sal/socket_api.h"
 
 using namespace mbed::Sockets::v0;
 UDPSocket::UDPSocket(socket_stack_t stack):

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed.h"
-#include "test_env.h"
+#include "mbed-drivers/mbed.h"
+#include "mbed-drivers/test_env.h"
 #include "sockets/TCPStream.h"
-#include "mbed-net-socket-abstract/test/ctest_env.h"
-#include "mbed-net-lwip/lwipv4_init.h"
-#include "EthernetInterface.h"
+#include "sal/test/ctest_env.h"
+#include "sal-stack-lwip/lwipv4_init.h"
+#include "sal-iface-eth/EthernetInterface.h"
 #include "minar/minar.h"
 #include "core-util/FunctionPointer.h"
 

--- a/test/echo-udp-client/main.cpp
+++ b/test/echo-udp-client/main.cpp
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed.h"
-#include "test_env.h"
-#include "mbed-net-socket-abstract/test/ctest_env.h"
+#include "mbed-drivers/mbed.h"
+#include "mbed-drivers/test_env.h"
+#include "sal/test/ctest_env.h"
+#include "sal/socket_api.h"
 #include <algorithm>
 #include "sockets/UDPSocket.h"
-#include "mbed-net-socket-abstract/socket_api.h"
-#include "EthernetInterface.h"
-#include "mbed-net-lwip/lwipv4_init.h"
+#include "sal-iface-eth/EthernetInterface.h"
+#include "sal-stack-lwip/lwipv4_init.h"
 #include "minar/minar.h"
 #include "core-util/FunctionPointer.h"
 


### PR DESCRIPTION
Remove (unused) Ticker from TCPStream
Add testDependency on mbed-drivers (to reflect reality)
Fix include-based warnings that stem from sockets includes