### PR TITLE
Porting tests to new utest-greentea framework

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,9 +21,9 @@
     "minar": "^1.0.0"
   },
   "testDependencies": {
-    "mbed-drivers": "~0.11.1",
+    "mbed-drivers": "~0.12.1",
     "unity": "^2.0.1",
-    "greentea-client": "^0.1.3"
+    "greentea-client": "^0.1.4"
   },
   "scripts": {
     "testReporter": [

--- a/module.json
+++ b/module.json
@@ -21,7 +21,9 @@
     "minar": "^1.0.0"
   },
   "testDependencies": {
-    "mbed-drivers": "~0.11.1"
+    "mbed-drivers": "~0.11.1",
+    "unity": "^2.0.1",
+    "greentea-client": "^0.1.3"
   },
   "scripts": {
     "testReporter": [

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 #include "mbed-drivers/mbed.h"
-#include "mbed-drivers/test_env.h"
 #include "sockets/TCPStream.h"
 #include "sal/test/ctest_env.h"
 #include "sal-stack-lwip/lwipv4_init.h"
 #include "sal-iface-eth/EthernetInterface.h"
 #include "minar/minar.h"
 #include "core-util/FunctionPointer.h"
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+
+using namespace utest::v1;
 
 struct s_ip_address {
     int ip_1;
@@ -41,6 +45,7 @@ void terminate(bool status, TCPEchoClient* client);
 
 char out_buffer[] = "Hello World\n";
 char buffer[256];
+char out_success[] = "{{success}}\n{{end}}\n";
 TCPEchoClient *client;
 int port;
 
@@ -51,20 +56,31 @@ public:
         {
             _stream.setOnError(TCPStream::ErrorHandler_t(this, &TCPEchoClient::onError));
         }
+    ~TCPEchoClient(){
+        if (_stream.isConnected())
+            _stream.close();
+    }
     void onError(Socket *s, socket_error_t err) {
         (void) s;
         printf("MBED: Socket Error: %s (%d)\r\n", socket_strerror(err), err);
         _done = true;
-        minar::Scheduler::postCallback(fpterminate_t(terminate).bind(TEST_RESULT(),this));
+        minar::Scheduler::postCallback(fpterminate_t(terminate).bind(false,this));
     }
     void start_test(char * host_addr, uint16_t port)
     {
+        printf("Trying to resolve address %s" NL, host_addr);
         _port = port;
         _done = false;
         _disconnected = true;
-        socket_error_t err = _stream.resolve(host_addr,TCPStream::DNSHandler_t(this, &TCPEchoClient::onDNS));
+        socket_error_t err = _stream.open(SOCKET_AF_INET4);
         if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
-            printf("MBED: TCPClient unable to connect to %s:%d" NL, buffer, port);
+            printf("MBED: TCPClient unable to open socket" NL);
+            onError(&_stream, err);
+        }
+        
+        err = _stream.resolve(host_addr,TCPStream::DNSHandler_t(this, &TCPEchoClient::onDNS));
+        if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+            printf("MBED: TCPClient unable to connect to %s:%d" NL, host_addr, port);
             onError(&_stream, err);
         }
     }
@@ -76,14 +92,12 @@ public:
         /* Open the socket */
         _resolvedAddr.fmtIPv6(buffer, sizeof(buffer));
         printf("MBED: Resolved %s to %s\r\n", domain, buffer);
-        socket_error_t err = _stream.open(SOCKET_AF_INET4);
-        TEST_EQ(err, SOCKET_ERROR_NONE);
         /* Register the read handler */
         _stream.setOnReadable(TCPStream::ReadableHandler_t(this, &TCPEchoClient::onRx));
         _stream.setOnSent(TCPStream::SentHandler_t(this, &TCPEchoClient::onSent));
         _stream.setOnDisconnect(TCPStream::DisconnectHandler_t(this, &TCPEchoClient::onDisconnect));
         /* Send the query packet to the remote host */
-        err = _stream.connect(_resolvedAddr, _port, TCPStream::ConnectHandler_t(this,&TCPEchoClient::onConnect));
+        socket_error_t err = _stream.connect(_resolvedAddr, _port, TCPStream::ConnectHandler_t(this,&TCPEchoClient::onConnect));
         if(!TEST_EQ(err, SOCKET_ERROR_NONE)) {
             printf("MBED: Expected %d, got %d (%s)\r\n", SOCKET_ERROR_NONE, err, socket_strerror(err));
             onError(&_stream, err);
@@ -93,10 +107,14 @@ public:
     {
         (void) s;
         _disconnected = false;
-        _unacked += sizeof(out_buffer) - 1;
+        _unacked = sizeof(out_buffer) - 1;
+        printf ("MBED: Sending (%d bytes) to host: %s" NL, _unacked, out_buffer);
         socket_error_t err = _stream.send(out_buffer, sizeof(out_buffer) - 1);
 
-        TEST_EQ(err, SOCKET_ERROR_NONE);
+        if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+            printf("MBED: TCPClient unable to send data!" NL);
+            onError(&_stream, err);
+        }
     }
     void onRx(Socket* s)
     {
@@ -105,36 +123,33 @@ public:
         socket_error_t err = _stream.recv(buffer, &n);
         TEST_EQ(err, SOCKET_ERROR_NONE);
         buffer[n] = 0;
-        char out_success[] = "{{success}}\n{{end}}\n";
-        char out_failure[] = "{{failure}}\n{{end}}\n";
-        int rc;
-        if (n > 0)
+        printf ("MBED: Rx (%d bytes) from host: %s" NL, n, buffer);
+        if (!_done && n > 0)
         {
-            buffer[n] = '\0';
-            printf("%s\r\n", buffer);
-            rc = strncmp(out_buffer, buffer, sizeof(out_buffer) - 1);
+            int rc = strncmp(out_buffer, buffer, sizeof(out_buffer) - 1);
             if (TEST_EQ(rc, 0)) {
                 _unacked += sizeof(out_success) - 1;
+                printf ("MBED: Sending (%d bytes) to host: %s" NL, _unacked, out_success);
                 err = _stream.send(out_success, sizeof(out_success) - 1);
                 _done = true;
-                TEST_EQ(err, SOCKET_ERROR_NONE);
-                minar::Scheduler::postCallback(fpterminate_t(terminate).bind(TEST_RESULT(),this));
+                if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
+                    printf("MBED: TCPClient unable to send data!" NL);
+                    onError(&_stream, err);
+                }
             }
         }
         if (!_done) {
-            _unacked += sizeof(out_failure) - 1;
-            err = _stream.send(out_failure, sizeof(out_failure) - 1);
-            _done = true;
-            TEST_EQ(err, SOCKET_ERROR_NONE);
-            minar::Scheduler::postCallback(fpterminate_t(terminate).bind(TEST_RESULT(),this));
+            // Failed to validate rceived data. Terminating...
+            minar::Scheduler::postCallback(fpterminate_t(terminate).bind(false,this));
         }
     }
     void onSent(Socket *s, uint16_t nbytes)
     {
         (void) s;
         _unacked -= nbytes;
+        printf ("MBED: Sent %d bytes" NL, nbytes);
         if (_done && (_unacked == 0)) {
-            _stream.close();
+            minar::Scheduler::postCallback(fpterminate_t(terminate).bind(true,this));
         }
     }
     void onDisconnect(TCPStream *s)
@@ -151,40 +166,82 @@ protected:
     volatile size_t _unacked;
 };
 
-void terminate(bool status, TCPEchoClient* client)
+void terminate(bool status, TCPEchoClient* )
 {
-    delete client;
-    eth.disconnect();
-    MBED_HOSTTEST_RESULT(status);
+    if (client) {
+        printf("MBED: Test finished!");
+        delete client;
+        client = NULL;
+        eth.disconnect();
+        // utest has two different APIs for pass and fail.
+        if (status) {
+            Harness::validate_callback();
+        } else {
+            Harness::raise_failure(REASON_CASES);
+        }
+    }
 }
 
 
-void app_start(int argc, char *argv[]) {
-    (void)argc;
-    (void)argv;
-    MBED_HOSTTEST_TIMEOUT(20);
-    MBED_HOSTTEST_SELECT(tcpecho_client_auto);
-    MBED_HOSTTEST_DESCRIPTION(TCP echo client);
-    MBED_HOSTTEST_START("NET_4");
+control_t test_echo_tcp_client()
+{
     socket_error_t err = lwipv4_socket_init();
     TEST_EQ(err, SOCKET_ERROR_NONE);
-
-    memset(buffer, 0, sizeof(buffer));
-    port = 0;
-    s_ip_address ip_addr = {0, 0, 0, 0};
-    printf("TCPClient waiting for server IP and port..." NL);
-    scanf("%d.%d.%d.%d:%d", &ip_addr.ip_1, &ip_addr.ip_2, &ip_addr.ip_3, &ip_addr.ip_4, &port);
-    printf("Address received:%d.%d.%d.%d:%d" NL, ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4, port);
-
+    
     eth.init(); //Use DHCP
     eth.connect();
 
     printf("TCPClient IP Address is %s" NL, eth.getIPAddress());
-    sprintf(buffer, "%d.%d.%d.%d", ip_addr.ip_1, ip_addr.ip_2, ip_addr.ip_3, ip_addr.ip_4);
+    greentea_send_kv("target_ip", eth.getIPAddress());
+    
+    memset(buffer, 0, sizeof(buffer));
+    port = 0;
+    
+    printf("TCPClient waiting for server IP and port..." NL);
+    char recv_key[] = "host_port";
+    char port_value[] = "65325";
+    
+    greentea_send_kv("host_ip", " ");
+    TEST_ASSERT_TRUE(greentea_parse_kv(recv_key, buffer, sizeof(recv_key), sizeof(buffer)) != 0);
+    
+    greentea_send_kv("host_port", " ");
+    TEST_ASSERT_TRUE(greentea_parse_kv(recv_key, port_value, sizeof(recv_key), sizeof(port_value)) != 0);
+    
+    sscanf(port_value, "%d", &port);
+    
+    
     client = new TCPEchoClient(SOCKET_STACK_LWIP_IPV4);
 
     {
         mbed::util::FunctionPointer2<void, char *, uint16_t> fp(client, &TCPEchoClient::start_test);
         minar::Scheduler::postCallback(fp.bind(buffer, port));
     }
+    return CaseTimeout(15000);
 }
+
+// Cases --------------------------------------------------------------------------------------------------------------
+Case cases[] = {
+    Case("Test Echo TCP Client", test_echo_tcp_client),
+};
+
+status_t greentea_setup(const size_t number_of_cases)
+{
+    // Handshake with greentea
+    // Host test timeout should be more than target utest timeout to let target cleanup the test and send test summary.
+    GREENTEA_SETUP(20, "tcpecho_client_auto"); 
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+void greentea_teardown(const size_t passed, const size_t failed, const failure_t failure)
+{
+    greentea_test_teardown_handler(passed, failed, failure);
+    GREENTEA_TESTSUITE_RESULT(failed == 0);
+}
+
+Specification specification(greentea_setup, cases, greentea_teardown);
+
+void app_start(int, char*[])
+{
+    Harness::run(specification);
+}
+

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -105,9 +105,8 @@ public:
         printf ("MBED: Rx (%d bytes) from host: %s" NL, n, buffer);
         if (!_done && n > 0)
         {
-            int rc = strncmp(out_buffer, buffer, sizeof(out_buffer) - 1);
-            TEST_ASSERT_EQUAL_MESSAGE(0, rc, "MBED: TCPClient round trip data validation failed!");
-
+            TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(out_buffer, buffer, n, "MBED: TCPClient round trip data validation failed!");
+            
             _unacked += sizeof(out_success) - 1;
             printf ("MBED: Sending (%d bytes) to host: %s" NL, _unacked, out_success);
             err = _stream.send(out_success, sizeof(out_success) - 1);

--- a/test/echo-tcp-client/main.cpp
+++ b/test/echo-tcp-client/main.cpp
@@ -26,15 +26,6 @@
 #include "unity/unity.h"
 
 using namespace utest::v1;
-
-struct s_ip_address {
-    int ip_1;
-    int ip_2;
-    int ip_3;
-    int ip_4;
-};
-
-
 using namespace mbed::Sockets::v0;
 
 EthernetInterface eth;
@@ -80,7 +71,7 @@ public:
         
         err = _stream.resolve(host_addr,TCPStream::DNSHandler_t(this, &TCPEchoClient::onDNS));
         if (!TEST_EQ(err, SOCKET_ERROR_NONE)) {
-            printf("MBED: TCPClient unable to connect to %s:%d" NL, host_addr, port);
+            printf("MBED: TCPClient unable to resolve address %s" NL, host_addr);
             onError(&_stream, err);
         }
     }

--- a/test/host_tests/tcpecho_client_auto.py
+++ b/test/host_tests/tcpecho_client_auto.py
@@ -19,7 +19,7 @@ import logging
 from threading import Thread
 from sys import stdout
 from SocketServer import BaseRequestHandler, TCPServer
-from mbed_host_tests import BaseHostTest
+from mbed_host_tests import BaseHostTest, event_callback
 
 
 class TCPEchoClientHandler(BaseRequestHandler):
@@ -162,6 +162,7 @@ class TCPEchoClientTest(BaseHostTest):
         """
         this.server.serve_forever()
 
+    @event_callback("target_ip")
     def _callback_target_ip(self, key, value, timestamp):
         """
         Callback to handle reception of target's IP address.
@@ -175,6 +176,7 @@ class TCPEchoClientTest(BaseHostTest):
         self.SERVER_IP = self.find_interface_to_target_addr(self.target_ip)
         self.setup_tcp_server()
 
+    @event_callback("host_ip")
     def _callback_host_ip(self, key, value, timestamp):
         """
         Callback for request for host IP Addr
@@ -182,16 +184,12 @@ class TCPEchoClientTest(BaseHostTest):
         """
         self.send_kv("host_ip", self.SERVER_IP)
 
+    @event_callback("host_port")
     def _callback_host_port(self, key, value, timestamp):
         """
         Callback for request for host port
         """
         self.send_kv("host_port", self.SERVER_PORT)
-
-    def setup(self):
-        self.register_callback("target_ip", self._callback_target_ip)
-        self.register_callback("host_ip", self._callback_host_ip)
-        self.register_callback("host_port", self._callback_host_port)
 
     def teardown(self):
         if self.server:

--- a/test/host_tests/tcpecho_client_auto.py
+++ b/test/host_tests/tcpecho_client_auto.py
@@ -1,0 +1,149 @@
+# Copyright 2015 ARM Limited, All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import socket
+import logging
+from threading import Thread
+from sys import stdout
+from SocketServer import BaseRequestHandler, TCPServer
+from mbed_host_tests import BaseHostTest
+
+
+class TCPEchoClient_Handler(BaseRequestHandler):
+    def handle(self):
+        """
+        One handle per connection
+        """
+        print ("HOST: TCPEchoClient_Handler: Connection received...")
+        while True:
+            try:
+                data = self.request.recv(1024)
+                if not data: break
+                print ('HOST: TCPEchoClient_Handler: \n%s\n' % data)
+
+                # If client finishes, sit on recv and terminate
+                # after client closes connection.
+                if '{{end}}' in data: continue
+
+                # echo data back to the client
+                self.request.sendall(data)
+            except Exception as e:
+                print ('HOST: TCPEchoClient_Handler: %s' % str(e))
+                break
+
+
+class TCPEchoClientTest(BaseHostTest):
+
+    __result = None
+    COUNT_MAX = 10
+    count = 0
+    uuid_sent = []
+    uuid_recv = []
+
+    def __init__(self):
+        """
+        Initialise test parameters.
+
+        :return:
+        """
+        super(BaseHostTest, self).__init__()
+        self.SERVER_IP = None # Will be determined after knowing the target IP
+        self.SERVER_PORT = 0  # Let TCPServer choose an arbitrary port
+        self.server = None
+        self.server_thread = None
+        self.target_ip = None
+
+    @staticmethod
+    def find_interface_to_target_addr(target_ip):
+        """
+        Finds IP address of the interface through which it is connected to the target.
+
+        :return:
+        """
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect((target_ip, 0)) # Target IP, Any port
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+
+    def setup_tcp_server(self):
+        """
+        sets up a TCP server for target to connect and send test data.
+
+        :return:
+        """
+        # !NOTE: There should mechanism to assert in the host test
+        if self.SERVER_IP is None:
+            self.log("setup_tcp_server() called before determining server IP!")
+            self.notify_complete(False)
+
+        # Returning none will suppress host test from printing success code
+        self.server = TCPServer((self.SERVER_IP, self.SERVER_PORT), TCPEchoClient_Handler)
+        ip, port = self.server.server_address
+        self.SERVER_PORT = port
+        self.server.allow_reuse_address = True
+        self.log("HOST: Listening for TCP connections: " + self.SERVER_IP + ":" + str(self.SERVER_PORT))
+        self.server_thread = Thread(target=TCPEchoClientTest.server_thread_func, args=(self,))
+        self.server_thread.start()
+
+    @staticmethod
+    def server_thread_func(this):
+        """
+        Thread function to run TCP server forever.
+
+        :param this:
+        :return:
+        """
+        this.server.serve_forever()
+
+    def _callback_target_ip(self, key, value, timestamp):
+        """
+        Callback to handle reception of target's IP address.
+
+        :param key:
+        :param value:
+        :param timestamp:
+        :return:
+        """
+        self.target_ip = value
+        self.SERVER_IP = self.find_interface_to_target_addr(self.target_ip)
+        self.setup_tcp_server()
+
+    def _callback_host_ip(self, key, value, timestamp):
+        """
+        Callback for request for host IP Addr
+
+        """
+        self.send_kv("host_ip", self.SERVER_IP)
+
+    def _callback_host_port(self, key, value, timestamp):
+        """
+        Callback for request for host port
+        """
+        self.send_kv("host_port", self.SERVER_PORT)
+
+    def setup(self):
+        self.register_callback("target_ip", self._callback_target_ip)
+        self.register_callback("host_ip", self._callback_host_ip)
+        self.register_callback("host_port", self._callback_host_port)
+
+    def result(self):
+        self.__result = self.uuid_sent == self.uuid_recv
+        return self.__result
+
+    def teardown(self):
+        if self.server:
+            self.server.shutdown()
+            self.server_thread.join()

--- a/test/host_tests/udpecho_client_auto.py
+++ b/test/host_tests/udpecho_client_auto.py
@@ -20,7 +20,7 @@ import socket
 from sys import stdout
 from threading import Thread
 from SocketServer import BaseRequestHandler, UDPServer
-from mbed_host_tests import BaseHostTest
+from mbed_host_tests import BaseHostTest, event_callback
 
 
 class UDPEchoClientHandler(BaseRequestHandler):
@@ -90,6 +90,7 @@ class UDPEchoClientTest(BaseHostTest):
         """
         this.server.serve_forever()
 
+    @event_callback("target_ip")
     def _callback_target_ip(self, key, value, timestamp):
         """
         Callback to handle reception of target's IP address.
@@ -103,6 +104,7 @@ class UDPEchoClientTest(BaseHostTest):
         self.SERVER_IP = self.find_interface_to_target_addr(self.target_ip)
         self.setup_udp_server()
 
+    @event_callback("host_ip")
     def _callback_host_ip(self, key, value, timestamp):
         """
         Callback for request for host IP Addr
@@ -110,16 +112,12 @@ class UDPEchoClientTest(BaseHostTest):
         """
         self.send_kv("host_ip", self.SERVER_IP)
 
+    @event_callback("host_port")
     def _callback_host_port(self, key, value, timestamp):
         """
         Callback for request for host port
         """
         self.send_kv("host_port", self.SERVER_PORT)
-
-    def setup(self):
-        self.register_callback("target_ip", self._callback_target_ip)
-        self.register_callback("host_ip", self._callback_host_ip)
-        self.register_callback("host_port", self._callback_host_port)
 
     def teardown(self):
         if self.server:


### PR DESCRIPTION
Following tests are ported to new utest-greentea framework. Also necessary changes have be done in the test code for tests to work and for clean tear down.
```
sockets-test-echo-tcp-client
sockets-test-echo-udp-client
```
For details on new utest - greentea framework please see description in PR https://github.com/ARMmbed/greentea/pull/78